### PR TITLE
Changed build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Binaries for KISS (musl) -> [here](https://github.com/kiss-community/repo-bin)
 ```sh
 export KISS_PATH=/path/to/grepo/bin:$KISS_PATH
 ```
-* The packages can now be installed by a simple `kiss b $PKG && kiss i $PKG` command.
+* The packages can now be installed by a simple `kiss b $PKG` command.
 
 ## NVIDIA
 


### PR DESCRIPTION
Running `kiss i` after `kiss b` is unnecessary any more, `kiss b` already lets you choose whether to install the built package or not (i.e. to run `kiss i` or not)