### PR TITLE
nvidia: clean libs + posix style soname linking

### DIFF
--- a/nvidia/nvidia/build
+++ b/nvidia/nvidia/build
@@ -23,20 +23,14 @@ persistenced
 "
 
 libs="
-libEGL_nvidia libGLESv1_CM_nvidia libGLESv2_nvidia
-libnvidia-cfg libnvidia-compiler libnvidia-eglcore libnvidia-glcore
-libnvidia-glsi libnvidia-glvkspirv libnvidia-rtcore libnvidia-allocator
-libcuda
+libEGL_nvidia      libGLESv1_CM_nvidia libGLESv2_nvidia
+libnvidia-eglcore  libnvidia-glcore    libnvidia-glsi  
+libnvidia-opencl   libnvidia-encode    libnvidia-rtcore 
+libnvidia-compiler libnvidia-allocator libnvidia-cfg  
+libnvidia-nvvm     libnvidia-tls       libnvidia-ml
+libnvcuvid         libcuda             libnvoptix
+libnvidia-ngx      libnvidia-glvkspirv libnvidia-opticalflow
 libnvidia-ptxjitcompiler
-libnvidia-nvvm
-libnvidia-opencl
-libnvidia-tls
-libnvidia-ml
-libnvcuvid
-libnvidia-encode
-libnvoptix
-libnvidia-opticalflow
-libnvidia-ngx
 "
 
 soname_libs="
@@ -97,6 +91,10 @@ if [ ! "$xorg" ] || [ "$wayland" ]; then
         sed 's|libGLX_nvidia.so.0|libEGL_nvidia.so.0|' "$file.json" > _
         mv -f _ "$file.json"
     done
+
+    # libnvidia-vulkan-producer.so has no SONAME set
+    ln -s "libnvidia-vulkan-producer.so.$2" "$1/usr/lib/libnvidia-vulkan-producer.so.1"
+    ln -s "libnvidia-vulkan-producer.so.$2" "$1/usr/lib/libnvidia-vulkan-producer.so"
 fi
 
 cp nvidia_icd.json "$1/etc/vulkan/icd.d/"
@@ -128,16 +126,13 @@ for lib in $soname_libs; do
 done
 
 # soname links
-for lib in "$1/usr/lib/"*.so*; do
-    soname=$(dirname "$lib")/$(readelf -d "$lib" | awk '/SONAME/ {print $5}' | tr -d '[]')
-    base=$(printf "%s" "$soname" | sed -r 's/(.*).so.*/\1.so/')
-    [ -e "$soname" ] || ln -sf "$(basename "$lib")" "$soname"
-    [ -e "$base" ] || ln -sf "$(basename "$soname")" "$base"
-done
+for lib in "$1"/usr/lib/*.so*; do  
+    soname="${lib%/*}/$(readelf -d "$lib" | awk -F'[][]' '/SONAME/ {print $2}')" 
+    base=${soname%%.so*} 
+    [ -e "$soname" ] || ln -sf "${lib##*/}" "${soname}" 
+    [ -e "$base" ] || ln -sf "${soname##*/}" "${base}.so" 
+done 
 
-# libnvidia-vulkan-producer.so has no SONAME set
-ln -s "libnvidia-vulkan-producer.so.$2" "$1/usr/lib/libnvidia-vulkan-producer.so.1"
-ln -s "libnvidia-vulkan-producer.so.$2" "$1/usr/lib/libnvidia-vulkan-producer.so"
 
 mkdir -p "$1/usr/lib/firmware/nvidia/$2"
 cp firmware/gsp.bin "$1/usr/lib/firmware/nvidia/$2/"


### PR DESCRIPTION
```
/var/db/kiss/installed/nvidia/version
/var/db/kiss/installed/nvidia/sources
/var/db/kiss/installed/nvidia/post-install
/var/db/kiss/installed/nvidia/manifest
/var/db/kiss/installed/nvidia/etcsums
/var/db/kiss/installed/nvidia/depends
/var/db/kiss/installed/nvidia/checksums
/var/db/kiss/installed/nvidia/build
/var/db/kiss/installed/nvidia/
/var/db/kiss/installed/
/var/db/kiss/
/var/db/
/var/
/usr/share/nvidia/nvidia-application-profiles-515.65.01-rc
/usr/share/nvidia/nvidia-application-profiles-515.65.01-key-documentation
/usr/share/nvidia/
/usr/share/man/man1/nvidia-xconfig.1.gz
/usr/share/man/man1/nvidia-smi.1.gz
/usr/share/man/man1/nvidia-settings.1.gz
/usr/share/man/man1/nvidia-persistenced.1.gz
/usr/share/man/man1/nvidia-modprobe.1.gz
/usr/share/man/man1/nvidia-cuda-mps-control.1.gz
/usr/share/man/man1/
/usr/share/man/
/usr/share/glvnd/egl_vendor.d/10_nvidia.json
/usr/share/glvnd/egl_vendor.d/
/usr/share/glvnd/
/usr/share/egl/egl_external_platform.d/
/usr/share/egl/
/usr/share/
/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.515.65.01
/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.1
/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so
/usr/lib/xorg/modules/extensions/
/usr/lib/xorg/modules/drivers/nvidia_drv.so
/usr/lib/xorg/modules/drivers/
/usr/lib/xorg/modules/
/usr/lib/xorg/
/usr/lib/vdpau/libvdpau_nvidia.so.515.65.01
/usr/lib/vdpau/libvdpau_nvidia.so.1
/usr/lib/vdpau/libvdpau_nvidia.so
/usr/lib/vdpau/
/usr/lib/modules/5.19.0-love-and-caring/extra/nvidia.ko
/usr/lib/modules/5.19.0-love-and-caring/extra/nvidia-uvm.ko
/usr/lib/modules/5.19.0-love-and-caring/extra/nvidia-peermem.ko
/usr/lib/modules/5.19.0-love-and-caring/extra/nvidia-modeset.ko
/usr/lib/modules/5.19.0-love-and-caring/extra/nvidia-drm.ko
/usr/lib/modules/5.19.0-love-and-caring/extra/
/usr/lib/modules/5.19.0-love-and-caring/
/usr/lib/modules/
/usr/lib/libnvoptix.so.515.65.01
/usr/lib/libnvoptix.so.1
/usr/lib/libnvoptix.so
/usr/lib/libnvidia-tls.so.515.65.01
/usr/lib/libnvidia-tls.so
/usr/lib/libnvidia-rtcore.so.515.65.01
/usr/lib/libnvidia-rtcore.so
/usr/lib/libnvidia-ptxjitcompiler.so.515.65.01
/usr/lib/libnvidia-ptxjitcompiler.so.1
/usr/lib/libnvidia-ptxjitcompiler.so
/usr/lib/libnvidia-opticalflow.so.515.65.01
/usr/lib/libnvidia-opticalflow.so.1
/usr/lib/libnvidia-opticalflow.so
/usr/lib/libnvidia-opencl.so.515.65.01
/usr/lib/libnvidia-opencl.so.1
/usr/lib/libnvidia-opencl.so
/usr/lib/libnvidia-nvvm.so.515.65.01
/usr/lib/libnvidia-nvvm.so.4
/usr/lib/libnvidia-nvvm.so
/usr/lib/libnvidia-ngx.so.515.65.01
/usr/lib/libnvidia-ngx.so.1
/usr/lib/libnvidia-ngx.so
/usr/lib/libnvidia-ml.so.515.65.01
/usr/lib/libnvidia-ml.so.1
/usr/lib/libnvidia-ml.so
/usr/lib/libnvidia-gtk3.so.515.65.01
/usr/lib/libnvidia-gtk3.so
/usr/lib/libnvidia-glvkspirv.so.515.65.01
/usr/lib/libnvidia-glvkspirv.so
/usr/lib/libnvidia-glsi.so.515.65.01
/usr/lib/libnvidia-glsi.so
/usr/lib/libnvidia-glcore.so.515.65.01
/usr/lib/libnvidia-glcore.so
/usr/lib/libnvidia-fbc.so.515.65.01
/usr/lib/libnvidia-fbc.so.1
/usr/lib/libnvidia-fbc.so
/usr/lib/libnvidia-encode.so.515.65.01
/usr/lib/libnvidia-encode.so.1
/usr/lib/libnvidia-encode.so
/usr/lib/libnvidia-eglcore.so.515.65.01
/usr/lib/libnvidia-eglcore.so
/usr/lib/libnvidia-compiler.so.515.65.01
/usr/lib/libnvidia-compiler.so
/usr/lib/libnvidia-cfg.so.515.65.01
/usr/lib/libnvidia-cfg.so.1
/usr/lib/libnvidia-cfg.so
/usr/lib/libnvidia-allocator.so.515.65.01
/usr/lib/libnvidia-allocator.so.1
/usr/lib/libnvidia-allocator.so
/usr/lib/libnvcuvid.so.515.65.01
/usr/lib/libnvcuvid.so.1
/usr/lib/libnvcuvid.so
/usr/lib/libcuda.so.515.65.01
/usr/lib/libcuda.so.1
/usr/lib/libcuda.so
/usr/lib/libOpenCL.so.1.0.0
/usr/lib/libOpenCL.so.1
/usr/lib/libOpenCL.so
/usr/lib/libGLX_nvidia.so.515.65.01
/usr/lib/libGLX_nvidia.so.0
/usr/lib/libGLX_nvidia.so
/usr/lib/libGLESv2_nvidia.so.515.65.01
/usr/lib/libGLESv2_nvidia.so.2
/usr/lib/libGLESv2_nvidia.so
/usr/lib/libGLESv1_CM_nvidia.so.515.65.01
/usr/lib/libGLESv1_CM_nvidia.so.1
/usr/lib/libGLESv1_CM_nvidia.so
/usr/lib/libEGL_nvidia.so.515.65.01
/usr/lib/libEGL_nvidia.so.0
/usr/lib/libEGL_nvidia.so
/usr/lib/gbm/
/usr/lib/firmware/nvidia/515.65.01/gsp.bin
/usr/lib/firmware/nvidia/515.65.01/
/usr/lib/firmware/nvidia/
/usr/lib/firmware/
/usr/lib/
/usr/bin/nvidia-xconfig
/usr/bin/nvidia-smi
/usr/bin/nvidia-settings
/usr/bin/nvidia-persistenced
/usr/bin/nvidia-modprobe
/usr/bin/nvidia-debugdump
/usr/bin/nvidia-cuda-mps-server
/usr/bin/nvidia-cuda-mps-control
/usr/bin/nvidia-bug-report.sh
/usr/bin/
/usr/
/etc/vulkan/implicit_layer.d/nvidia_layers.json
/etc/vulkan/implicit_layer.d/
/etc/vulkan/icd.d/nvidia_icd.json
/etc/vulkan/icd.d/
/etc/vulkan/
/etc/OpenCL/vendors/nvidia.icd
/etc/OpenCL/vendors/
/etc/OpenCL/
/etc/
```